### PR TITLE
Add support for versioning datetime attributes

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import setup
 
 
-VERSION = '0.1.1'
+VERSION = '0.1.2'
 INSTALL_REQUIRES = [
     'SQLAlchemy>=1.0.0',
     'simplejson',


### PR DESCRIPTION
# Problem
If a versioned model contains a SQLAlchemy `DateTime` column, versioning fails with the error `Object of type datetime is not JSON serializable`. It will be nice if versionalchemy can provide some elegant handling of the super-common `datetime`  objects.

# Solution
Add a custom `json.JSONEncoder` that returns the `isoformat` of any `datetime` object. This is useful since this format can be loaded back into MySQL/Postgres `TIMESTAMP` columns like so:

```sql
CREATE TABLE test(
  time TIMESTAMP
);

/* In Python, the below value is generated like so:
 * In [1]: import datetime
 * In [2]: datetime.datetime.now().isoformat()
 * Out[7]: '2017-08-15T14:36:07.351909'
 */
INSERT INTO test VALUES ('2017-08-15T14:36:07.351909');
```
Fiddles: [MySQL 5.6](http://sqlfiddle.com/#!9/bc449e/1) | [Postgres 9.6](http://sqlfiddle.com/#!17/bc449/1)
cc/ @ryankirkman 