### PR TITLE
Update ci configs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: python
 python:
-- 2.7.8
 - 2.7
 env:
 - SA_VERSION=1.0.0

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,9 +2,9 @@ language: python
 python:
 - 2.7
 env:
-- SA_VERSION=1.0.0
-- SA_VERSION=1.0.4
-- SA_VERSION=1.0.14
+- SA_VERSION=1.0.19
+- SA_VERSION=1.1.13
+- SA_VERSION=1.2.0b2
 cache:
   directories:
   - "$HOME/.cache/pip"

--- a/scripts/assert_full_coverage.py
+++ b/scripts/assert_full_coverage.py
@@ -18,5 +18,6 @@ def main():
         print 'Your test coverage is not 100%'
         sys.exit(-1)
 
+
 if __name__ == '__main__':
     main()


### PR DESCRIPTION
# Problem
- Travis CI [breaks](https://github.com/travis-ci/travis-ci/issues/8153) with python 2.7.8. The resolution seems to be to upgrade to 2.7.9
- `versionalchemy` doesn't seem to do enough with python internals to care about minor version bumps
- `sqlalchemy` now has `1.0` and `1.1` deprecated, with `1.2` having active development.

# Solution
- Stop tracking specific python minor versions.
- Track specific versions of `sqlalchemy` `1.0` and `1.1`; Track edge version of `1.2`